### PR TITLE
Add user registration and JWT authentication

### DIFF
--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -1,23 +1,53 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.auth import (
     UserRegisterRequest,
     UserLoginRequest,
     AuthTokenResponse,
 )
+from app.core.db import get_db_session
+from app.domain.auth.repositories import UserRepository
+from app.infrastructure.db.repositories.user_repository import SqlAlchemyUserRepository
+from app.infrastructure.auth.password import PasswordHasher
+from app.infrastructure.auth.jwt import create_access_token
+from app.application.auth.use_cases.register_user import RegisterUserUseCase
+from app.application.auth.use_cases.authenticate_user import AuthenticateUserUseCase
 
 
 router = APIRouter()
 
 
+def get_user_repository(session: AsyncSession = Depends(get_db_session)) -> UserRepository:
+    return SqlAlchemyUserRepository(session)
+
+
 @router.post("/register", response_model=AuthTokenResponse, status_code=201)
-async def register_user(payload: UserRegisterRequest) -> AuthTokenResponse:
-    raise HTTPException(status_code=501, detail="Not implemented")
+async def register_user(
+    payload: UserRegisterRequest, repo: UserRepository = Depends(get_user_repository)
+) -> AuthTokenResponse:
+    hasher = PasswordHasher()
+    use_case = RegisterUserUseCase(user_repository=repo, password_hasher=hasher)
+    try:
+        user = await use_case.execute(payload.login, payload.email, payload.password)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="User already exists")
+    token = create_access_token(user.id)
+    return AuthTokenResponse(access_token=token)
 
 
 @router.post("/login", response_model=AuthTokenResponse)
-async def login_user(payload: UserLoginRequest) -> AuthTokenResponse:
-    raise HTTPException(status_code=501, detail="Not implemented")
+async def login_user(
+    payload: UserLoginRequest, repo: UserRepository = Depends(get_user_repository)
+) -> AuthTokenResponse:
+    hasher = PasswordHasher()
+    use_case = AuthenticateUserUseCase(user_repository=repo, password_hasher=hasher)
+    try:
+        user = await use_case.execute(payload.login, payload.password)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_access_token(user.id)
+    return AuthTokenResponse(access_token=token)
 
 
 

--- a/app/application/auth/use_cases/authenticate_user.py
+++ b/app/application/auth/use_cases/authenticate_user.py
@@ -1,14 +1,20 @@
 from dataclasses import dataclass
 
+from app.domain.auth.entities import User
 from app.domain.auth.repositories import UserRepository
+from app.infrastructure.auth.password import PasswordHasher
 
 
 @dataclass
 class AuthenticateUserUseCase:
     user_repository: UserRepository
+    password_hasher: PasswordHasher
 
-    async def execute(self, email: str, password: str) -> str:
-        raise NotImplementedError
+    async def execute(self, login: str, password: str) -> User:
+        user = await self.user_repository.get_by_login(login)
+        if not user or not self.password_hasher.verify(password, user.password_hash):
+            raise ValueError("Invalid credentials")
+        return user
 
 
 

--- a/app/application/auth/use_cases/register_user.py
+++ b/app/application/auth/use_cases/register_user.py
@@ -1,14 +1,20 @@
 from dataclasses import dataclass
 
+from app.domain.auth.entities import User
 from app.domain.auth.repositories import UserRepository
+from app.infrastructure.auth.password import PasswordHasher
 
 
 @dataclass
 class RegisterUserUseCase:
     user_repository: UserRepository
+    password_hasher: PasswordHasher
 
-    async def execute(self, email: str, password: str) -> str:
-        raise NotImplementedError
+    async def execute(self, login: str, email: str, password: str) -> User:
+        if await self.user_repository.get_by_email(email) or await self.user_repository.get_by_login(login):
+            raise ValueError("User already exists")
+        password_hash = self.password_hasher.hash(password)
+        return await self.user_repository.create(login=login, email=email, password_hash=password_hash)
 
 
 

--- a/app/domain/auth/entities.py
+++ b/app/domain/auth/entities.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
-from uuid import UUID
 
 
 @dataclass
 class User:
-    id: UUID
+    id: str
+    login: str
     email: str
     password_hash: str
 

--- a/app/domain/auth/repositories.py
+++ b/app/domain/auth/repositories.py
@@ -11,7 +11,11 @@ class UserRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def create(self, email: str, password_hash: str) -> User:
+    async def get_by_login(self, login: str) -> Optional[User]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def create(self, login: str, email: str, password_hash: str) -> User:
         raise NotImplementedError
 
 

--- a/app/infrastructure/auth/jwt.py
+++ b/app/infrastructure/auth/jwt.py
@@ -1,0 +1,27 @@
+import base64
+import json
+import hmac
+import hashlib
+import time
+from datetime import timedelta
+
+from app.core.settings import settings
+
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+
+def _b64encode(data: bytes) -> bytes:
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+
+def create_access_token(subject: str, expires_delta: timedelta | None = None) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    expire = int(time.time() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)).total_seconds())
+    payload = {"sub": subject, "exp": expire}
+    header_b64 = _b64encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = b".".join([header_b64, payload_b64])
+    signature = _b64encode(
+        hmac.new(settings.secret_key.encode(), signing_input, hashlib.sha256).digest()
+    )
+    return b".".join([signing_input, signature]).decode()

--- a/app/infrastructure/auth/password.py
+++ b/app/infrastructure/auth/password.py
@@ -1,9 +1,17 @@
+import base64
+import hashlib
+import hmac
+import os
+
+
 class PasswordHasher:
     def hash(self, password: str) -> str:
-        raise NotImplementedError
+        salt = os.urandom(16)
+        hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100000)
+        return base64.b64encode(salt + hashed).decode()
 
     def verify(self, password: str, password_hash: str) -> bool:
-        raise NotImplementedError
-
-
-
+        data = base64.b64decode(password_hash.encode())
+        salt, hashed = data[:16], data[16:]
+        new_hash = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100000)
+        return hmac.compare_digest(hashed, new_hash)

--- a/app/infrastructure/db/models/user.py
+++ b/app/infrastructure/db/models/user.py
@@ -1,7 +1,6 @@
 import uuid
 
 from sqlalchemy import String
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.infrastructure.db.base import Base
@@ -10,7 +9,8 @@ from app.infrastructure.db.base import Base
 class UserModel(Base):
     __tablename__ = "users"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    login: Mapped[str] = mapped_column(String(50), unique=True, index=True, nullable=False)
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
 

--- a/app/infrastructure/db/repositories/user_repository.py
+++ b/app/infrastructure/db/repositories/user_repository.py
@@ -13,10 +13,27 @@ class SqlAlchemyUserRepository(UserRepository):
         self._session = session
 
     async def get_by_email(self, email: str) -> Optional[User]:
-        raise NotImplementedError
+        stmt = select(UserModel).where(UserModel.email == email)
+        result = await self._session.execute(stmt)
+        model = result.scalars().first()
+        if model:
+            return User(id=model.id, login=model.login, email=model.email, password_hash=model.password_hash)
+        return None
 
-    async def create(self, email: str, password_hash: str) -> User:
-        raise NotImplementedError
+    async def get_by_login(self, login: str) -> Optional[User]:
+        stmt = select(UserModel).where(UserModel.login == login)
+        result = await self._session.execute(stmt)
+        model = result.scalars().first()
+        if model:
+            return User(id=model.id, login=model.login, email=model.email, password_hash=model.password_hash)
+        return None
+
+    async def create(self, login: str, email: str, password_hash: str) -> User:
+        model = UserModel(login=login, email=email, password_hash=password_hash)
+        self._session.add(model)
+        await self._session.commit()
+        await self._session.refresh(model)
+        return User(id=model.id, login=model.login, email=model.email, password_hash=model.password_hash)
 
 
 

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,13 +1,14 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel
 
 
 class UserRegisterRequest(BaseModel):
-    email: EmailStr
+    login: str
+    email: str
     password: str
 
 
 class UserLoginRequest(BaseModel):
-    email: EmailStr
+    login: str
     password: str
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import asyncio
+import pytest
+from fastapi import HTTPException
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.api.v1.routes.auth import register_user, login_user
+from app.domain.auth.entities import User
+from app.domain.auth.repositories import UserRepository
+from app.schemas.auth import UserRegisterRequest, UserLoginRequest
+
+
+class InMemoryUserRepository(UserRepository):
+    def __init__(self) -> None:
+        self.users: dict[str, User] = {}
+
+    async def get_by_email(self, email: str) -> User | None:
+        for user in self.users.values():
+            if user.email == email:
+                return user
+        return None
+
+    async def get_by_login(self, login: str) -> User | None:
+        return self.users.get(login)
+
+    async def create(self, login: str, email: str, password_hash: str) -> User:
+        user = User(id=login, login=login, email=email, password_hash=password_hash)
+        self.users[login] = user
+        return user
+
+
+def test_register_and_login():
+    repo = InMemoryUserRepository()
+    response = asyncio.run(
+        register_user(
+            UserRegisterRequest(login="user1", email="user1@example.com", password="secret"),
+            repo=repo,
+        )
+    )
+    assert response.access_token
+
+    response = asyncio.run(
+        login_user(
+            UserLoginRequest(login="user1", password="secret"),
+            repo=repo,
+        )
+    )
+    assert response.access_token
+
+
+def test_login_wrong_password():
+    repo = InMemoryUserRepository()
+    asyncio.run(
+        register_user(
+            UserRegisterRequest(login="user2", email="user2@example.com", password="secret"),
+            repo=repo,
+        )
+    )
+    with pytest.raises(HTTPException):
+        asyncio.run(
+            login_user(
+                UserLoginRequest(login="user2", password="wrong"),
+                repo=repo,
+            )
+        )


### PR DESCRIPTION
## Summary
- add user model, repository, and routes for registering and logging in with JWT tokens
- implement password hashing and token generation utilities
- cover registration and login flows with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbb40691008332ae766832879c79a2