### PR TITLE
Refactor chat session tracking and persistence

### DIFF
--- a/app/api/v1/routes/chat.py
+++ b/app/api/v1/routes/chat.py
@@ -4,6 +4,9 @@ import asyncio
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.application.chat.use_cases.start_chat_session import StartChatSessionUseCase
+from app.application.chat.use_cases.submit_user_message import SubmitUserMessageUseCase
+from app.application.chat.use_cases.bot_ask_question import BotAskQuestionUseCase
 from app.schemas.chat import (
     StartChatSessionRequest,
     StartChatSessionResponse,
@@ -26,21 +29,48 @@ def get_chat_repository(session: AsyncSession = Depends(get_db_session)) -> Chat
 
 
 @router.post("/sessions", response_model=StartChatSessionResponse, status_code=201)
-async def start_chat_session(payload: StartChatSessionRequest) -> StartChatSessionResponse:
-    raise HTTPException(status_code=501, detail="Not implemented")
+async def start_chat_session(
+    payload: StartChatSessionRequest,
+    repo: ChatRepository = Depends(get_chat_repository),
+) -> StartChatSessionResponse:
+    session_id, question, created_at = await StartChatSessionUseCase(repo).execute(
+        payload.user_id
+    )
+    return StartChatSessionResponse(
+        session_id=session_id, created_at=created_at, question=question
+    )
 
 
 @router.post(
     "/sessions/{session_id}/messages",
     response_model=ChatMessageResponse,
 )
-async def submit_user_message(session_id: UUID, payload: SubmitMessageRequest) -> ChatMessageResponse:
-    raise HTTPException(status_code=501, detail="Not implemented")
+async def submit_user_message(
+    session_id: UUID,
+    payload: SubmitMessageRequest,
+    repo: ChatRepository = Depends(get_chat_repository),
+) -> ChatMessageResponse:
+    message = await SubmitUserMessageUseCase(repo).execute(session_id, payload.content)
+    return ChatMessageResponse(
+        message_id=message.id,
+        session_id=message.session_id,
+        content=message.content,
+        role=message.role,
+        created_at=message.created_at,
+    )
 
 
 @router.get("/sessions/{session_id}/next", response_model=BotQuestionResponse)
-async def get_next_bot_question(session_id: UUID) -> BotQuestionResponse:
-    raise HTTPException(status_code=501, detail="Not implemented")
+async def get_next_bot_question(
+    session_id: UUID, repo: ChatRepository = Depends(get_chat_repository)
+) -> BotQuestionResponse:
+    try:
+        question = await BotAskQuestionUseCase(repo).execute(session_id)
+    except StopAsyncIteration:
+        raise HTTPException(status_code=404, detail="No more questions")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return BotQuestionResponse(session_id=session_id, question=question)
 
 
 @router.websocket("/ws")
@@ -56,28 +86,50 @@ async def chat_websocket(
         return
     user_uuid = UUID(user_id)
     session = await repo.get_latest_session(user_uuid)
-    messages = []
-    if session:
-        messages = await repo.list_messages(session.id)
-        answers_count = len([m for m in messages if m.role == "user"])
-        if answers_count >= len(QUESTIONS):
-            session = await repo.create_session(user_uuid)
-            messages = []
-            answers_count = 0
-    else:
+    if not session or session.answers_count >= len(QUESTIONS):
         session = await repo.create_session(user_uuid)
-        answers_count = 0
+    user_messages = await repo.list_messages(session.id)
 
-    for m in messages:
-        await websocket.send_json({"role": m.role, "content": m.content})
+    for i in range(1, session.question_index + 1):
+        question = QUESTIONS[i - 1]
+        if i <= session.answers_count and i <= len(user_messages):
+            await websocket.send_json({"role": "bot", "content": question["prompt"]})
+            await websocket.send_json(
+                {"role": "user", "content": user_messages[i - 1].content}
+            )
+        else:
+            await websocket.send_json({"id": question["id"], "prompt": question["prompt"]})
 
-    last_user_message = next((m.content for m in reversed(messages) if m.role == "user"), None)
-    idx = answers_count
+    last_user_message = (
+        user_messages[-1].content if user_messages and session.answers_count > 0 else None
+    )
+
+    if session.question_index > session.answers_count:
+        question = QUESTIONS[session.question_index - 1]
+        while True:
+            try:
+                user_reply = await websocket.receive_text()
+            except WebSocketDisconnect:
+                return
+            if last_user_message is not None and user_reply == last_user_message:
+                await websocket.send_json({"error": "duplicate"})
+                await websocket.send_json(
+                    {"id": question["id"], "prompt": question["prompt"]}
+                )
+                continue
+            await repo.add_message(session.id, "user", user_reply)
+            last_user_message = user_reply
+            session = await repo.update_session(
+                session.id, answers_count=session.answers_count + 1
+            )
+            break
+
+    idx = session.answers_count
     while idx < len(QUESTIONS):
         question = QUESTIONS[idx]
-        await repo.add_message(session.id, "bot", question["prompt"])
         while True:
             await websocket.send_json({"id": question["id"], "prompt": question["prompt"]})
+            await repo.update_session(session.id, question_index=idx + 1)
             try:
                 user_reply = await websocket.receive_text()
             except WebSocketDisconnect:
@@ -87,15 +139,10 @@ async def chat_websocket(
                 continue
             await repo.add_message(session.id, "user", user_reply)
             last_user_message = user_reply
-            while True:
-                try:
-                    await asyncio.wait_for(websocket.receive_text(), timeout=0.01)
-                except asyncio.TimeoutError:
-                    break
-                except WebSocketDisconnect:
-                    return
+            await repo.update_session(session.id, answers_count=idx + 1)
             break
         idx += 1
+    await repo.update_session(session.id, status="finished")
     await websocket.send_json({"event": "finished"})
     await websocket.close()
 

--- a/app/api/v1/routes/chat.py
+++ b/app/api/v1/routes/chat.py
@@ -86,8 +86,8 @@ async def chat_websocket(
         return
     user_uuid = UUID(user_id)
     session = await repo.get_latest_session(user_uuid)
-    if not session or session.answers_count >= len(QUESTIONS):
-        session = await repo.create_session(user_uuid)
+    if not session or session.answers_count >= len(QUESTIONS) or session.status == "finished":
+        session = await repo.create_session(user_uuid, question_index=1)
     user_messages = await repo.list_messages(session.id)
 
     for i in range(1, session.question_index + 1):
@@ -97,7 +97,7 @@ async def chat_websocket(
             await websocket.send_json(
                 {"role": "user", "content": user_messages[i - 1].content}
             )
-        else:
+        elif i == session.question_index:
             await websocket.send_json({"id": question["id"], "prompt": question["prompt"]})
 
     last_user_message = (

--- a/app/application/chat/use_cases/bot_ask_question.py
+++ b/app/application/chat/use_cases/bot_ask_question.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from app.domain.chat.repositories import ChatRepository
+from app.domain.chat.questions import QUESTIONS
 
 
 @dataclass
@@ -9,7 +10,17 @@ class BotAskQuestionUseCase:
     chat_repository: ChatRepository
 
     async def execute(self, session_id: UUID) -> str:
-        raise NotImplementedError
+        session = await self.chat_repository.get_session(session_id)
+        if not session:
+            raise ValueError("session not found")
+        if session.question_index >= len(QUESTIONS):
+            await self.chat_repository.update_session(session_id, status="finished")
+            raise StopAsyncIteration
+        question = QUESTIONS[session.question_index]["prompt"]
+        await self.chat_repository.update_session(
+            session_id, question_index=session.question_index + 1
+        )
+        return question
 
 
 

--- a/app/application/chat/use_cases/start_chat_session.py
+++ b/app/application/chat/use_cases/start_chat_session.py
@@ -1,15 +1,23 @@
 from dataclasses import dataclass
+from datetime import datetime
 from uuid import UUID
 
 from app.domain.chat.repositories import ChatRepository
+from app.domain.chat.questions import QUESTIONS
 
 
 @dataclass
 class StartChatSessionUseCase:
     chat_repository: ChatRepository
 
-    async def execute(self, user_id: UUID) -> UUID:
-        raise NotImplementedError
+    async def execute(self, user_id: UUID) -> tuple[UUID, str, datetime]:
+        session = await self.chat_repository.get_latest_session(user_id)
+        if session and session.status == "active" and session.answers_count < len(QUESTIONS):
+            question = QUESTIONS[session.question_index]["prompt"]
+            return session.id, question, session.created_at
+        session = await self.chat_repository.create_session(user_id, question_index=1)
+        question = QUESTIONS[0]["prompt"]
+        return session.id, question, session.created_at
 
 
 

--- a/app/application/chat/use_cases/submit_user_message.py
+++ b/app/application/chat/use_cases/submit_user_message.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
+from app.domain.chat.entities import Message
 from app.domain.chat.repositories import ChatRepository
 
 
@@ -8,8 +9,13 @@ from app.domain.chat.repositories import ChatRepository
 class SubmitUserMessageUseCase:
     chat_repository: ChatRepository
 
-    async def execute(self, session_id: UUID, content: str) -> UUID:
-        raise NotImplementedError
+    async def execute(self, session_id: UUID, content: str) -> Message:
+        message = await self.chat_repository.add_message(session_id, "user", content)
+        session = await self.chat_repository.get_session(session_id)
+        await self.chat_repository.update_session(
+            session_id, answers_count=session.answers_count + 1
+        )
+        return message
 
 
 

--- a/app/domain/chat/entities.py
+++ b/app/domain/chat/entities.py
@@ -8,6 +8,9 @@ class ChatSession:
     id: UUID
     user_id: UUID
     created_at: datetime
+    status: str
+    question_index: int
+    answers_count: int
 
 
 @dataclass

--- a/app/domain/chat/repositories.py
+++ b/app/domain/chat/repositories.py
@@ -38,9 +38,9 @@ class ChatRepository(ABC):
         self,
         session_id: UUID,
         *,
-        status: str | None = None,
-        question_index: int | None = None,
-        answers_count: int | None = None,
+        status: Optional[str] = None,
+        question_index: Optional[int] = None,
+        answers_count: Optional[int] = None,
     ) -> ChatSession:
         raise NotImplementedError
 

--- a/app/domain/chat/repositories.py
+++ b/app/domain/chat/repositories.py
@@ -7,7 +7,14 @@ from .entities import ChatSession, Message
 
 class ChatRepository(ABC):
     @abstractmethod
-    async def create_session(self, user_id: UUID) -> ChatSession:
+    async def create_session(
+        self,
+        user_id: UUID,
+        *,
+        status: str = "active",
+        question_index: int = 0,
+        answers_count: int = 0,
+    ) -> ChatSession:
         raise NotImplementedError
 
     @abstractmethod
@@ -20,6 +27,21 @@ class ChatRepository(ABC):
 
     @abstractmethod
     async def get_latest_session(self, user_id: UUID) -> Optional[ChatSession]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_session(self, session_id: UUID) -> Optional[ChatSession]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def update_session(
+        self,
+        session_id: UUID,
+        *,
+        status: str | None = None,
+        question_index: int | None = None,
+        answers_count: int | None = None,
+    ) -> ChatSession:
         raise NotImplementedError
 
 

--- a/app/infrastructure/db/models/chat_session.py
+++ b/app/infrastructure/db/models/chat_session.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy import DateTime, ForeignKey, String, Integer
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.infrastructure.db.base import Base
@@ -13,6 +13,9 @@ class ChatSessionModel(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
+    question_index: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    answers_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
 
 

--- a/app/infrastructure/db/repositories/chat_repository.py
+++ b/app/infrastructure/db/repositories/chat_repository.py
@@ -118,9 +118,9 @@ class SqlAlchemyChatRepository(ChatRepository):
         self,
         session_id: UUID,
         *,
-        status: str | None = None,
-        question_index: int | None = None,
-        answers_count: int | None = None,
+        status: Optional[str] = None,
+        question_index: Optional[int] = None,
+        answers_count: Optional[int] = None,
     ) -> ChatSession:
         stmt = select(ChatSessionModel).where(ChatSessionModel.id == str(session_id))
         result = await self._session.execute(stmt)

--- a/app/infrastructure/db/repositories/chat_repository.py
+++ b/app/infrastructure/db/repositories/chat_repository.py
@@ -15,12 +15,32 @@ class SqlAlchemyChatRepository(ChatRepository):
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def create_session(self, user_id: UUID) -> ChatSession:
-        model = ChatSessionModel(user_id=str(user_id), created_at=datetime.utcnow())
+    async def create_session(
+        self,
+        user_id: UUID,
+        *,
+        status: str = "active",
+        question_index: int = 0,
+        answers_count: int = 0,
+    ) -> ChatSession:
+        model = ChatSessionModel(
+            user_id=str(user_id),
+            created_at=datetime.utcnow(),
+            status=status,
+            question_index=question_index,
+            answers_count=answers_count,
+        )
         self._session.add(model)
         await self._session.commit()
         await self._session.refresh(model)
-        return ChatSession(id=UUID(model.id), user_id=UUID(model.user_id), created_at=model.created_at)
+        return ChatSession(
+            id=UUID(model.id),
+            user_id=UUID(model.user_id),
+            created_at=model.created_at,
+            status=model.status,
+            question_index=model.question_index,
+            answers_count=model.answers_count,
+        )
 
     async def add_message(self, session_id: UUID, role: str, content: str) -> Message:
         model = MessageModel(
@@ -69,8 +89,58 @@ class SqlAlchemyChatRepository(ChatRepository):
         result = await self._session.execute(stmt)
         model = result.scalars().first()
         if model:
-            return ChatSession(id=UUID(model.id), user_id=UUID(model.user_id), created_at=model.created_at)
+            return ChatSession(
+                id=UUID(model.id),
+                user_id=UUID(model.user_id),
+                created_at=model.created_at,
+                status=model.status,
+                question_index=model.question_index,
+                answers_count=model.answers_count,
+            )
         return None
+
+    async def get_session(self, session_id: UUID) -> Optional[ChatSession]:
+        stmt = select(ChatSessionModel).where(ChatSessionModel.id == str(session_id))
+        result = await self._session.execute(stmt)
+        model = result.scalars().first()
+        if model:
+            return ChatSession(
+                id=UUID(model.id),
+                user_id=UUID(model.user_id),
+                created_at=model.created_at,
+                status=model.status,
+                question_index=model.question_index,
+                answers_count=model.answers_count,
+            )
+        return None
+
+    async def update_session(
+        self,
+        session_id: UUID,
+        *,
+        status: str | None = None,
+        question_index: int | None = None,
+        answers_count: int | None = None,
+    ) -> ChatSession:
+        stmt = select(ChatSessionModel).where(ChatSessionModel.id == str(session_id))
+        result = await self._session.execute(stmt)
+        model = result.scalars().one()
+        if status is not None:
+            model.status = status
+        if question_index is not None:
+            model.question_index = question_index
+        if answers_count is not None:
+            model.answers_count = answers_count
+        await self._session.commit()
+        await self._session.refresh(model)
+        return ChatSession(
+            id=UUID(model.id),
+            user_id=UUID(model.user_id),
+            created_at=model.created_at,
+            status=model.status,
+            question_index=model.question_index,
+            answers_count=model.answers_count,
+        )
 
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import uvicorn
 
 from app.api.v1.routes.auth import router as auth_router
 from app.api.v1.routes.chat import router as chat_router
@@ -26,5 +27,6 @@ def create_app() -> FastAPI:
 
 app = create_app()
 
-
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)
 

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -12,6 +12,7 @@ class StartChatSessionRequest(BaseModel):
 class StartChatSessionResponse(BaseModel):
     session_id: UUID
     created_at: datetime
+    question: str
 
 
 class SubmitMessageRequest(BaseModel):
@@ -30,6 +31,3 @@ class BotQuestionResponse(BaseModel):
     session_id: UUID
     question: str
     context: Optional[dict] = None
-
-
-

--- a/migrations/versions/0003_add_session_fields.py
+++ b/migrations/versions/0003_add_session_fields.py
@@ -1,0 +1,31 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0003_add_session_fields"
+down_revision = "0002_create_chat_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_sessions",
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="active"),
+    )
+    op.add_column(
+        "chat_sessions",
+        sa.Column("question_index", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "chat_sessions",
+        sa.Column("answers_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.alter_column("chat_sessions", "status", server_default=None)
+    op.alter_column("chat_sessions", "question_index", server_default=None)
+    op.alter_column("chat_sessions", "answers_count", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("chat_sessions", "answers_count")
+    op.drop_column("chat_sessions", "question_index")
+    op.drop_column("chat_sessions", "status")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "career-coach-be",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -3,6 +3,7 @@ import sys
 import asyncio
 from datetime import datetime
 from uuid import uuid4
+from typing import Optional
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -64,9 +65,9 @@ class InMemoryChatRepository(ChatRepository):
         self,
         session_id,
         *,
-        status: str | None = None,
-        question_index: int | None = None,
-        answers_count: int | None = None,
+        status: Optional[str] = None,
+        question_index: Optional[int] = None,
+        answers_count: Optional[int] = None,
     ):
         for sessions in self.sessions.values():
             for s in sessions:

--- a/ui/src/app/App.jsx
+++ b/ui/src/app/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import AuthPage from '../pages/AuthPage.jsx';
-import HomePage from '../pages/HomePage.jsx';
+import ChatPage from '../pages/ChatPage.jsx';
 
 function App() {
   const [token, setToken] = useState(null);
@@ -26,7 +26,7 @@ function App() {
     return <AuthPage onAuth={handleAuth} />;
   }
 
-  return <HomePage onLogout={handleLogout} />;
+  return <ChatPage token={token} onLogout={handleLogout} />;
 }
 
 export default App;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -54,3 +54,209 @@ button.link {
   color: red;
   margin-bottom: 1rem;
 }
+
+/* Chat Styles */
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-width: 800px;
+  margin: 0 auto;
+  background: #fff;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #007bff;
+  color: white;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.chat-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.connection-status {
+  font-size: 0.9rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.connection-status.connected {
+  color: #90EE90;
+}
+
+.connection-status.disconnected {
+  color: #FFB6C1;
+}
+
+.new-chat-btn, .logout-btn, .retry-btn {
+  width: auto;
+  padding: 0.5rem 1rem;
+  margin: 0;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.new-chat-btn:hover, .logout-btn:hover, .retry-btn:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.error-message {
+  background: #ffebee;
+  color: #c62828;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #ffcdd2;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.messages-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.welcome-message {
+  text-align: center;
+  color: #666;
+  font-style: italic;
+  padding: 2rem;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  max-width: 70%;
+  word-wrap: break-word;
+}
+
+.message.user {
+  align-self: flex-end;
+}
+
+.message.user .message-content {
+  background: #007bff;
+  color: white;
+  padding: 0.75rem 1rem;
+  border-radius: 18px 18px 4px 18px;
+}
+
+.message.bot .message-content {
+  background: #f1f1f1;
+  color: #333;
+  padding: 0.75rem 1rem;
+  border-radius: 18px 18px 18px 4px;
+}
+
+.message.system .message-content {
+  background: #e8f5e8;
+  color: #2e7d32;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  text-align: center;
+  font-style: italic;
+}
+
+.message.error .message-content {
+  background: #ffebee;
+  color: #c62828;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border-left: 4px solid #f44336;
+}
+
+.message-time {
+  font-size: 0.75rem;
+  color: #999;
+  margin-top: 0.25rem;
+  align-self: flex-end;
+}
+
+.message.user .message-time {
+  align-self: flex-start;
+}
+
+.typing-indicator {
+  display: flex;
+  gap: 4px;
+  padding: 0.5rem 0;
+}
+
+.typing-indicator span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #999;
+  animation: typing 1.4s infinite ease-in-out;
+}
+
+.typing-indicator span:nth-child(1) { animation-delay: -0.32s; }
+.typing-indicator span:nth-child(2) { animation-delay: -0.16s; }
+
+@keyframes typing {
+  0%, 80%, 100% { transform: scale(0.8); opacity: 0.5; }
+  40% { transform: scale(1); opacity: 1; }
+}
+
+.input-container {
+  display: flex;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #e0e0e0;
+  background: #fafafa;
+  gap: 0.5rem;
+}
+
+.message-input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 20px;
+  outline: none;
+  font-size: 1rem;
+  margin: 0;
+}
+
+.message-input:focus {
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.message-input:disabled {
+  background: #f5f5f5;
+  color: #999;
+}
+
+.send-btn {
+  width: auto;
+  padding: 0.75rem 1.5rem;
+  border-radius: 20px;
+  margin: 0;
+  font-weight: 500;
+}
+
+.send-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.send-btn:disabled:hover {
+  background: #ccc;
+}

--- a/ui/src/pages/ChatPage.jsx
+++ b/ui/src/pages/ChatPage.jsx
@@ -1,0 +1,227 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+function ChatPage({ token, onLogout }) {
+  const [messages, setMessages] = useState([]);
+  const [currentInput, setCurrentInput] = useState('');
+  const [isConnected, setIsConnected] = useState(false);
+  const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+  const [error, setError] = useState(null);
+  const wsRef = useRef(null);
+  const messagesEndRef = useRef(null);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  useEffect(() => {
+    connectWebSocket();
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, [token]);
+
+  const connectWebSocket = () => {
+    try {
+      const wsUrl = `ws://127.0.0.1:8000/api/v1/chat/ws?token=${token}`;
+      const ws = new WebSocket(wsUrl);
+      
+      ws.onopen = () => {
+        console.log('WebSocket connected');
+        setIsConnected(true);
+        setError(null);
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          console.log('Received:', data);
+          
+          if (data.event === 'finished') {
+            setMessages(prev => [...prev, {
+              type: 'system',
+              content: 'Спасибо за ответы! Диалог завершен. Вы можете начать новый диалог.',
+              timestamp: new Date()
+            }]);
+            setIsWaitingForResponse(false);
+          } else if (data.error === 'duplicate') {
+            setMessages(prev => [...prev, {
+              type: 'error',
+              content: 'Пожалуйста, дайте другой ответ (не повторяйте предыдущий).',
+              timestamp: new Date()
+            }]);
+            setIsWaitingForResponse(false);
+          } else if (data.id && data.prompt) {
+            // Новый вопрос от бота
+            setMessages(prev => [...prev, {
+              type: 'bot',
+              content: data.prompt,
+              questionId: data.id,
+              timestamp: new Date()
+            }]);
+            setIsWaitingForResponse(false);
+          } else if (data.role === 'bot' && data.content) {
+            // Предыдущий вопрос (при восстановлении сессии)
+            setMessages(prev => [...prev, {
+              type: 'bot',
+              content: data.content,
+              timestamp: new Date()
+            }]);
+          } else if (data.role === 'user' && data.content) {
+            // Предыдущий ответ пользователя (при восстановлении сессии)
+            setMessages(prev => [...prev, {
+              type: 'user',
+              content: data.content,
+              timestamp: new Date()
+            }]);
+          }
+        } catch (e) {
+          console.error('Error parsing message:', e);
+          setError('Ошибка обработки сообщения от сервера');
+        }
+      };
+
+      ws.onclose = (event) => {
+        console.log('WebSocket closed:', event.code, event.reason);
+        setIsConnected(false);
+        if (event.code !== 1000) {
+          setError('Соединение с сервером потеряно');
+        }
+      };
+
+      ws.onerror = (error) => {
+        console.error('WebSocket error:', error);
+        setError('Ошибка соединения с сервером');
+        setIsConnected(false);
+      };
+
+      wsRef.current = ws;
+    } catch (e) {
+      console.error('Failed to connect WebSocket:', e);
+      setError('Не удалось подключиться к серверу');
+    }
+  };
+
+  const sendMessage = () => {
+    if (!currentInput.trim() || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    const message = currentInput.trim();
+    
+    // Добавляем сообщение пользователя в чат
+    setMessages(prev => [...prev, {
+      type: 'user',
+      content: message,
+      timestamp: new Date()
+    }]);
+
+    // Отправляем сообщение на сервер
+    wsRef.current.send(message);
+    setCurrentInput('');
+    setIsWaitingForResponse(true);
+  };
+
+  const handleKeyPress = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  const startNewChat = () => {
+    setMessages([]);
+    setError(null);
+    if (wsRef.current) {
+      wsRef.current.close();
+    }
+    setTimeout(connectWebSocket, 100);
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="chat-header">
+        <h2>Карьерный консультант</h2>
+        <div className="header-controls">
+          <div className={`connection-status ${isConnected ? 'connected' : 'disconnected'}`}>
+            {isConnected ? '🟢 Подключено' : '🔴 Не подключено'}
+          </div>
+          <button onClick={startNewChat} className="new-chat-btn">
+            Новый диалог
+          </button>
+          <button onClick={onLogout} className="logout-btn">
+            Выйти
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="error-message">
+          {error}
+          <button onClick={connectWebSocket} className="retry-btn">
+            Переподключиться
+          </button>
+        </div>
+      )}
+
+      <div className="messages-container">
+        {messages.length === 0 && isConnected && (
+          <div className="welcome-message">
+            Добро пожаловать! Ожидайте первый вопрос от консультанта...
+          </div>
+        )}
+        
+        {messages.map((msg, index) => (
+          <div key={index} className={`message ${msg.type}`}>
+            <div className="message-content">
+              {msg.content}
+            </div>
+            <div className="message-time">
+              {msg.timestamp.toLocaleTimeString()}
+            </div>
+          </div>
+        ))}
+        
+        {isWaitingForResponse && (
+          <div className="message bot typing">
+            <div className="message-content">
+              <div className="typing-indicator">
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+            </div>
+          </div>
+        )}
+        
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="input-container">
+        <input
+          type="text"
+          value={currentInput}
+          onChange={(e) => setCurrentInput(e.target.value)}
+          onKeyPress={handleKeyPress}
+          placeholder="Введите ваш ответ..."
+          disabled={!isConnected || isWaitingForResponse}
+          className="message-input"
+        />
+        <button
+          onClick={sendMessage}
+          disabled={!isConnected || !currentInput.trim() || isWaitingForResponse}
+          className="send-btn"
+        >
+          Отправить
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ChatPage;


### PR DESCRIPTION
## Summary
- track chat session status, question index and answer counts
- expose use cases and HTTP routes for starting sessions, asking questions and saving answers
- rework websocket flow to persist only user answers and resume unfinished sessions

## Testing
- `pytest tests/test_chat.py -q`
- `pytest -q` *(fails: docker.errors.DockerException: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68bd07666dc48332985390d9629dfe1b